### PR TITLE
EncodeBase64 modified to remove not valid chars

### DIFF
--- a/source/Anthropic.Httpx.pas
+++ b/source/Anthropic.Httpx.pas
@@ -111,7 +111,7 @@ begin
     {$IF RTLVersion >= 35.0}
     Result := TNetEncoding.Base64String.EncodeBytesToString(DataBytes);
     {$ELSE}
-    Result := TNetEncoding.Base64.EncodeBytesToString(ImageBytes);
+    Result := TNetEncoding.Base64.EncodeBytesToString(DataBytes);
     {$ENDIF}
   finally
     HttpClient.Free;

--- a/source/Anthropic.NetEncoding.Base64.pas
+++ b/source/Anthropic.NetEncoding.Base64.pas
@@ -67,6 +67,17 @@ implementation
 uses
   System.StrUtils;
 
+function CleanBase64String(const ABase64: string): string;
+begin
+  // Remove non valid chars
+  Result := ABase64;
+  Result := StringReplace(Result, #13, '', [rfReplaceAll]);
+  Result := StringReplace(Result, #10, '', [rfReplaceAll]);
+  Result := StringReplace(Result, ' ', '', [rfReplaceAll]);
+  Result := StringReplace(Result, #9, '', [rfReplaceAll]);
+end;
+
+
 function EncodeBase64(FileLocation : string): string;
 begin
   if not FileExists(FileLocation) then
@@ -82,7 +93,7 @@ begin
     {$ELSE}
     TNetEncoding.Base64.Encode(Stream, StreamOutput);
     {$ENDIF}
-    Result := StreamOutput.DataString;
+    Result := CleanBase64String( StreamOutput.DataString );
   finally
     Stream.Free;
     StreamOutput.Free;


### PR DESCRIPTION
EncodeBase64 is not correct with delphi 10.4.
The pdf files are not valid. 
Need to remove the chars not valid from string before sending to api.